### PR TITLE
Replace custom stubbing with sinon

### DIFF
--- a/src/stub.ts
+++ b/src/stub.ts
@@ -1,31 +1,17 @@
-import * as _ from 'lodash'
+import * as sinon from 'sinon'
 
 /**
  * mocks an object's property
  */
-export default function<T extends object, K extends keyof T> (object: T, path: K, value: () => T[K]) {
+export default function<T extends object, K extends keyof T> (object: T, path: K, value: any) {
   if (object === undefined || path === undefined) throw new Error('should not be undefined')
+
   return {
-    run(ctx: {stubs: any[]}) {
-      ctx.stubs = ctx.stubs || []
-      const descriptor = Object.getOwnPropertyDescriptor(object, path)
-      if (descriptor && descriptor.get) {
-        ctx.stubs.push(descriptor.get)
-        descriptor.get = value
-        Object.defineProperty(object, path, descriptor)
-      } else {
-        ctx.stubs.push(_.get(object, path))
-        _.set(object, path, value)
-      }
-    }, finally(ctx: {stubs: any[]}) {
-      const stub = ctx.stubs.pop()
-      const descriptor = Object.getOwnPropertyDescriptor(object, path)
-      if (descriptor && descriptor.get) {
-        descriptor.get = stub
-        Object.defineProperty(object, path, descriptor)
-      } else {
-        _.set(object, path, stub)
-      }
+    run(ctx: {sandbox: any}) {
+      const sandbox = ctx.sandbox = ctx.sandbox || sinon.createSandbox()
+      sandbox.stub(object, path).value(value)
+    }, finally(ctx: {sandbox: any}) {
+      ctx.sandbox.restore()
     },
   }
 }

--- a/test/stub.test.ts
+++ b/test/stub.test.ts
@@ -38,7 +38,7 @@ describe('stub', () => {
 
   fancy
     .stdout()
-    .stub(mrGetter, 'foo', () => 2)
+    .stub(mrGetter, 'foo', 2)
     .end('resets getter', output => {
       console.log(mrGetter.foo)
       expect(output.stdout).to.equal('2\n')


### PR DESCRIPTION
This solves two issues:
1. Letting sinon do the heavy work of stubbing, tracking stubs, and handling any edge cases around stubbing.
2. Fix an issue where getters have to be wrapped in an extra function.

On that second point we were running into an issue where if you are stubbing an object you had to know if the property was a getter or not, which is difficult when the thing is imported from a dependency, ie:

Both should be consistently stubbed via `.stub(obj, 'prop', 'abc')`:

```
const obj = {
  prop: 'abc';
}
```

```
const obj = {
  get prop() {
    return 'abc';
  }
}
```

Where currently, a regular object can be stubbed like `.stub(obj, 'prop', 'abc')` and a getter is stubbed like `.stub(obj, 'prop', () => 'abc')` (as seen in the tests).

Because this would change the way getters are stubbed this would be a breaking change for fancy-test where existing getter stubs would have to drop a function wrapper.