### PR TITLE
fix: bring Done in from mocha

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "dependencies": {
     "@types/chai": "*",
     "@types/lodash": "*",
-    "@types/mocha": "*",
     "@types/node": "*",
     "@types/sinon": "*",
     "lodash": "^4.17.13",
@@ -15,6 +14,7 @@
     "stdout-stderr": "^0.1.9"
   },
   "devDependencies": {
+    "@types/mocha": "*",
     "chai": "^4.2.0",
     "chalk": "^2.4.2",
     "eslint": "^6.6.0",

--- a/src/base.ts
+++ b/src/base.ts
@@ -35,7 +35,7 @@ const base = <I extends Types.Context>(context: I): Types.Base<I, {}> => {
       arg1 = undefined
     }
     if (!arg1) arg1 = context.expectation || 'test'
-    async function run(this: Types.ITestCallbackContext, done?: Mocha.Done) {
+    async function run(this: Types.ITestCallbackContext, done?: Types.MochaDone) {
       context = assignWithProps({}, originalContext)
       if (context.retries) this.retries(context.retries)
       if (cb) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,7 +34,7 @@ export interface ITestCallbackContext {
   [index: string]: any;
 }
 
-export type MochaCallback<I> = (this: ITestCallbackContext, context: I, done: Mocha.Done) => any
+export type MochaCallback<I> = (this: ITestCallbackContext, context: I, done: MochaDone) => any
 export interface It<I> {
   (expectation: string, cb?: MochaCallback<I>): void;
   (cb?: MochaCallback<I>): void;
@@ -52,6 +52,8 @@ export type Base<I extends Context, T extends Plugins> = {
 export interface EnvOptions {
   clear?: boolean;
 }
+
+export type MochaDone = (err?: any) => void
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface NockScope extends Nock.Scope {}


### PR DESCRIPTION
Hi there. I've been using `fancy-test` (by way of `@oclif/test`) and using Jest as my test runner (since that's what I was already using to run all the tests in my monorepo), and it pretty much just works. It's been great.

The only thing I've run into is that I have to include `@types/jest` in my monorepo, and since I do, when I try to build my package with TypeScript, I get some errors that look like this:

```
../../node_modules/@types/jest/index.d.ts:44:13 - error TS2403: Subsequent variable declarations must have the same type.  Variable 'test' must be of type 'TestFunction', but here has type 'It'.

44 declare var test: jest.It;
               ~~~~

  ../../node_modules/@types/mocha/index.d.ts:2817:13
    2817 declare var test: Mocha.TestFunction;
                     ~~~~
    'test' was also declared here.
```

I've been able to get around this by setting `"skipLibCheck": true` in my `tsconfig.json`, but I'd like to not skip checks if possible.

This PR brings in mocha's `Done` type (basically the same kind of thing that was already done in https://github.com/oclif/fancy-test/commit/d0111928df307a7435d8e23645e529d39e648adf). It also moves `@types/mocha` to devDependencies instead of dependencies, since after this change as far as I can tell the mocha types aren't used in the src code itself. By moving `@types/mocha` to devDependencies, if you add `fancy-test` it to a project, it won't add `@types/mocha`, too, and you can avoid clashes with `@types/jest`.
